### PR TITLE
feat(imports): fixing issue on dropdown component

### DIFF
--- a/stories/components/layout/FilterToolbar/FilterToolbar.jsx
+++ b/stories/components/layout/FilterToolbar/FilterToolbar.jsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { ButtonGroup } from "../../ui/ButtonGroup/ButtonGroup";
 import { ButtonMenuIcon } from "../../ui/ButtonMenuIcon/ButtonMenuIcon";
-import { Dropdown } from "../../ui/Dropdown/Dropdown";
+import { Dropdown } from "../../ui/dropdown/Dropdown";
 import "./_filterToolbar.scss";
 
 export const FilterToolbar = () => {


### PR DESCRIPTION
Webpack build was failing due to a case sensitivity error in the FilterToolbar component import statement.

### 🎯 Root Cause
The import path for the Dropdown component had incorrect casing:
- **Incorrect**: `"../../ui/Dropdown/Dropdown"` (uppercase D)
- **Actual directory**: `../../ui/dropdown/` (lowercase d)

This triggered webpack's `CaseSensitivePathsPlugin` error, preventing the project from building.

### ✅ Solution
Fixed the import path casing in `FilterToolbar.jsx`:
